### PR TITLE
Use the Grouping Module for the Error and add message

### DIFF
--- a/lib/slop_matching_type.rb
+++ b/lib/slop_matching_type.rb
@@ -5,7 +5,7 @@ module Slop
   class MatchingTypeOption < Option
     def call(value)
       unless Grouping::Matcher::TYPES.include?(value)
-        raise Matcher::UnknownMatcherTypeError.new
+        raise Grouping::UnknownMatcherTypeError.new("#{value} is not a valid matcher")
       end
       type = value.split("_").collect(&:capitalize).join
       Grouping.const_get("#{type}MatchingType")

--- a/lib/slop_matching_type.rb
+++ b/lib/slop_matching_type.rb
@@ -5,7 +5,9 @@ module Slop
   class MatchingTypeOption < Option
     def call(value)
       unless Grouping::Matcher::TYPES.include?(value)
-        raise Grouping::UnknownMatcherTypeError.new("#{value} is not a valid matcher")
+        raise Grouping::UnknownMatcherTypeError.new(
+          "#{value} is not a valid matcher"
+        )
       end
       type = value.split("_").collect(&:capitalize).join
       Grouping.const_get("#{type}MatchingType")


### PR DESCRIPTION
I bumped in to this issue when I accidentally ran the test with an incorrect matcher name. This was the output:

> ![image](https://user-images.githubusercontent.com/3384/77868762-ef16bd00-7201-11ea-99c8-85bfcbc8c750.png)

Once the correct Module was specified, this was the output:

> ![image](https://user-images.githubusercontent.com/3384/77868797-081f6e00-7202-11ea-82d9-3563316bd117.png)

I found that to be a little confusing, so I added a more informative error message:

> ![image](https://user-images.githubusercontent.com/3384/77868713-cb537700-7201-11ea-9f87-fe9c5444ba0d.png)
